### PR TITLE
Enhanced security for control panel access

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -41,7 +41,7 @@ resource "google_container_cluster" "gke_cluster" {
         display_name = cidr_blocks.value.display_name
       }
     }
-    gcp_public_cidrs_access_enabled = true
+    gcp_public_cidrs_access_enabled = false
   }
 
   # Private Cluster Configuration


### PR DESCRIPTION
Enhanced security for control panel, disable public access to gke cluster.

gcp_public_cidrs_access_enabled: false